### PR TITLE
Removes lifecycle annotations from CricketCoach

### DIFF
--- a/src/main/java/com/dj/springcoredemo/common/CricketCoach.java
+++ b/src/main/java/com/dj/springcoredemo/common/CricketCoach.java
@@ -1,7 +1,5 @@
 package com.dj.springcoredemo.common;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,18 +7,6 @@ public class CricketCoach implements Coach{
 
     public CricketCoach() {
         System.out.println("In constructor: " + getClass().getSimpleName());
-    }
-
-    // define our init method
-    @PostConstruct
-    public void doMyStartupStuff(){
-        System.out.println("In doMyStartupStuff: " + getClass().getSimpleName());
-    }
-
-    // define our destroy method
-    @PreDestroy
-    public void doMyCleanupStuff(){
-        System.out.println("In doMyCleanupStuff: " + getClass().getSimpleName());
     }
 
     @Override


### PR DESCRIPTION
Removes `@PostConstruct` and `@PreDestroy` annotations along with their associated methods to simplify the class. This change may reflect a shift away from using explicit lifecycle hooks in favor of alternative approaches for initialization and cleanup.